### PR TITLE
修复【9.一个关于模块的小故事】代码示例中bug

### DIFF
--- a/zh_CN/9-a-story-on-cyclic-imports.md
+++ b/zh_CN/9-a-story-on-cyclic-imports.md
@@ -37,8 +37,8 @@ from fancy_site.marketing import query_user_points
 
 def main():
     """获取所有的活跃用户，将积分情况发送给他们"""
-    users = get_active_users()
-    points = list_user_points(users)
+    users = list_active_users()
+    points = query_user_points(users)
     for user in users:
         user.add_notification(... ...)
         #  <... 已省略 ...>


### PR DESCRIPTION
根据上下文可以发现，文中 `notify_users.py` 里导入的方法为：

> from fancy_site.users import list_active_users
from fancy_site.marketing import query_user_points

`notify_users.py` 使用导入方法为：

> def main():
    """获取所有的活跃用户，将积分情况发送给他们"""
    users = get_active_users()
    points = list_user_points(users)
    for user in users:
        user.add_notification(... ...)
        #  <... 已省略 ...>

可以发现  `users = get_active_users()`，`points = list_user_points(users)` 对应的方法是不存在的，没有导入的；

结合下文 `fancy_site/users.py`，`fancy_site/marketing.py` 可确定`notify_users.py` 导入方法时没问题，在使用方法时方法名写错了；